### PR TITLE
Allowed to pass undefined as a value

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-declare function yn (value: string | number | boolean, options?: yn.Options): boolean | null;
+declare function yn (value?: string | number | boolean, options?: yn.Options): boolean | null;
 
 declare namespace yn {
   export interface Options {


### PR DESCRIPTION
This is for https://github.com/TypeStrong/ts-node/pull/413#discussion_r135891896.

Implementation will use default value if `undefined` is passed in as `value`.